### PR TITLE
Update for Typst 0.13.0

### DIFF
--- a/packages/preview/octique/0.1.0/impl/octique.typ
+++ b/packages/preview/octique/0.1.0/impl/octique.typ
@@ -332,8 +332,8 @@
 
 // Returns decoded image for name
 #let _octique-image(name, color: rgb("#000000"), width: 1em, height: 1em) = {
-  image.decode(
-    _octique-svg(name).replace("#000000", color.to-hex()),
+  image(
+    bytes(_octique-svg(name).replace("#000000", color.to-hex())),
     width: width,
     height: height,
     alt: name,


### PR DESCRIPTION
I believe this will update octique so there are no warnings when using it with Typst 0.13.0.

I haven't bumped version numbers or anything like that - I don't know how you'd want to handle that! But hopefully this PR will save you a few minutes work... :wink: 